### PR TITLE
chore: reject TV streaming feature after evaluation

### DIFF
--- a/docs/research/2025-12-tv-streaming-research.md
+++ b/docs/research/2025-12-tv-streaming-research.md
@@ -1,12 +1,27 @@
 # TV & Streaming Research: Where to Watch Real Betis Matches in the UK
 
 **Date**: December 2025  
-**Status**: Research Complete  
+**Status**: ❌ Not Implementing  
 **Related Feature**: TV & Streaming Integration (ideas.md)
 
-## Executive Summary
+## Decision: Not Implementing
 
-This document provides research on where Real Betis matches are broadcast in the **United Kingdom**, including TV channels, streaming services, and implementation recommendations for the Peña Bética Escocesa website.
+After prototyping this feature, we decided **not to implement** a "Where to Watch" section on the website.
+
+### Reasons:
+1. **All services are paid** - There are no free options to watch La Liga in the UK
+2. **Adds noise** - This information doesn't add real value to our users; everyone knows they need Premier Sports
+3. **Polwarth Tavern is the answer** - Our members watch matches together at the pub, not at home
+4. **Maintenance burden** - Keeping pricing and service info up to date isn't worth the effort
+
+### What we'd tell users:
+> "Come watch at Polwarth Tavern! If you must watch at home, you'll need Premier Sports (~£15/month)."
+
+---
+
+## Original Research (Archived)
+
+This document originally provided research on where Real Betis matches are broadcast in the **United Kingdom**, including TV channels, streaming services, and implementation recommendations. Keeping for reference.
 
 ---
 
@@ -138,11 +153,13 @@ The pub likely has:
 
 ## 📋 Next Steps
 
-1. **Decision Required**: Choose implementation approach (A, B, or C)
-2. **Content Creation**: Write user-friendly "Where to Watch" content
-3. **Design**: Create TV/streaming info component matching site aesthetic
-4. **Integration**: Add to matches page or create dedicated section
-5. **Testing**: Verify all links work and info is accurate
+~~1. **Decision Required**: Choose implementation approach (A, B, or C)~~  
+~~2. **Content Creation**: Write user-friendly "Where to Watch" content~~  
+~~3. **Design**: Create TV/streaming info component matching site aesthetic~~  
+~~4. **Integration**: Add to matches page or create dedicated section~~  
+~~5. **Testing**: Verify all links work and info is accurate~~
+
+**Decision**: None - feature rejected. Polwarth Tavern is the place to watch!
 
 ---
 

--- a/tasks/ideas.md
+++ b/tasks/ideas.md
@@ -10,13 +10,14 @@ This document provides a list of ideas and features for the Peña Bética Escoce
 | User Features | ✅ Dashboard, ✅ RSVP, ✅ Contact, ✅ GDPR | 🔄 GDPR Dashboard Integration | Enhanced Profiles, GitHub Issues |
 | Games | ✅ Daily Trivia | - | Lineup, Score, Crossword, Penalty |
 | Push Notifications | ✅ Admin | - | User reminders |
-| Other | ✅ TV Research, ✅ AI Research, ✅ Soylenti Research | - | La Porra, E-commerce, Voting, i18n |
+| Other | ❌ TV (rejected), ✅ AI Research, ✅ Soylenti Research | - | La Porra, E-commerce, Voting, i18n |
 
 ## 🎯 **Core Feature Ideas**
 
-### TV & Streaming Integration
-* Find where Betis matches are shown on TV in the UK, with links to channels and streaming services.
-* 📋 **Research Complete**: See [docs/research/2025-12-tv-streaming-research.md](../docs/research/2025-12-tv-streaming-research.md) for full analysis
+### ~~TV & Streaming Integration~~ ❌ **Not Implementing**
+* ~~Find where Betis matches are shown on TV in the UK, with links to channels and streaming services.~~
+* 📋 **Research Complete**: See [docs/research/2025-12-tv-streaming-research.md](../docs/research/2025-12-tv-streaming-research.md)
+* **Decision**: Not implementing - all UK options are paid services (Premier Sports ~£15/month), adds noise without real value. Polwarth Tavern is where we watch together! 🍺
 
 ### La Porra Enhancement
 * Make the porra private only for Peña members, so that we don't get in a legal trouble with the gambling commission. Also it is a skill based game, not gambling. 50/50 split of the prize pool, 50% to the winner, 50% to the Peña (donation for the yearly celebration).


### PR DESCRIPTION
## Summary

After prototyping and evaluating the "Where to Watch" feature, decided **not to implement** it.

### Reasons for rejection:
- 📺 All UK options are paid services (Premier Sports ~£15/month)
- 🔇 Adds noise without providing real value to users
- 🍺 **Polwarth Tavern is the answer** - that's where members watch matches together!

### Changes:
- Updated research doc (`docs/research/2025-12-tv-streaming-research.md`) to reflect decision
- Updated `tasks/ideas.md` status table - marked TV feature as ❌ rejected

## Test plan
- [x] Documentation-only changes, no code affected
- [x] CI should pass (type-check and lint already passed in pre-commit)