### PR TITLE
fix: add secret fallbacks for sync-rumors workflow

### DIFF
--- a/.github/workflows/sync-rumors.yml
+++ b/.github/workflows/sync-rumors.yml
@@ -29,9 +29,9 @@ jobs:
 
       - name: Run rumor sync
         env:
-          # Production database for sync script
-          SUPABASE_SYNC_URL: ${{ secrets.SUPABASE_PRODUCTION_URL }}
-          SUPABASE_SYNC_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_PRODUCTION_SERVICE_ROLE_KEY }}
+          # Use production-specific secrets if available, otherwise fall back to standard secrets
+          SUPABASE_SYNC_URL: ${{ secrets.SUPABASE_PRODUCTION_URL || secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          SUPABASE_SYNC_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_PRODUCTION_SERVICE_ROLE_KEY || secrets.SUPABASE_SERVICE_ROLE_KEY }}
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GEMINI_MODEL: 'gemini-3-flash-preview'
         run: npm run sync-rumors


### PR DESCRIPTION
## Summary

The sync-rumors workflow was failing because the production-specific secrets (`SUPABASE_PRODUCTION_URL`, `SUPABASE_PRODUCTION_SERVICE_ROLE_KEY`) don't exist in GitHub yet. Added fallback logic to use standard secrets when production secrets aren't configured.

This makes the workflow work with whatever secrets are available:
- If production secrets exist → uses production database
- If only standard secrets exist → uses those as fallback

## Changes

- Added `|| secrets.NEXT_PUBLIC_SUPABASE_URL` fallback for URL
- Added `|| secrets.SUPABASE_SERVICE_ROLE_KEY` fallback for service role key

## Test plan

- [ ] CI passes
- [ ] Manually trigger sync-rumors workflow to verify it runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)