### PR TITLE
fix(soylenti): handle string aiProbability from database

### DIFF
--- a/src/app/soylenti/SoylentiClient.tsx
+++ b/src/app/soylenti/SoylentiClient.tsx
@@ -64,8 +64,8 @@ export default function SoylentiClient({
     () =>
       rumorsToFilter
         .filter((rumor) => {
-          const prob = rumor.aiProbability;
-          const isTransfer = prob !== null && prob !== undefined && prob > 0;
+          const prob = Number(rumor.aiProbability);
+          const isTransfer = !isNaN(prob) && prob > 0;
           return isTransfer || showAllNews;
         })
         .sort(
@@ -78,8 +78,8 @@ export default function SoylentiClient({
   const rumorCount = useMemo(
     () =>
       rumorsToFilter.filter((r) => {
-        const prob = r.aiProbability;
-        return prob !== null && prob !== undefined && prob > 0;
+        const prob = Number(r.aiProbability);
+        return !isNaN(prob) && prob > 0;
       }).length,
     [rumorsToFilter],
   );

--- a/src/components/RumorCard.tsx
+++ b/src/components/RumorCard.tsx
@@ -62,23 +62,27 @@ export default function RumorCard({
             >
               {source}
             </span>
-            {showCredibility &&
-              aiProbability !== null &&
-              aiProbability !== undefined &&
-              aiProbability > 0 && (
-                <span
-                  className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                    aiProbability >= 70
-                      ? "bg-betis-verde text-white"
-                      : aiProbability >= 40
-                        ? "bg-betis-oro text-betis-verde-dark"
-                        : "bg-gray-200 text-gray-700"
-                  }`}
-                  title={aiAnalysis || undefined}
-                >
-                  {aiProbability}%
-                </span>
-              )}
+            {(() => {
+              const prob = Number(aiProbability);
+              return (
+                showCredibility &&
+                !isNaN(prob) &&
+                prob > 0 && (
+                  <span
+                    className={`px-2 py-0.5 rounded-full text-xs font-medium ${
+                      prob >= 70
+                        ? "bg-betis-verde text-white"
+                        : prob >= 40
+                          ? "bg-betis-oro text-betis-verde-dark"
+                          : "bg-gray-200 text-gray-700"
+                    }`}
+                    title={aiAnalysis || undefined}
+                  >
+                    {Math.round(prob)}%
+                  </span>
+                )
+              );
+            })()}
           </div>
           <span className="text-sm text-gray-500">{formatDate(pubDate)}</span>
         </div>


### PR DESCRIPTION
## Summary

The `ai_probability` column returns as a string from Supabase (e.g., "30.00" instead of 30). Fixed comparisons to explicitly convert to `Number()` before comparing, ensuring news items with valid probability are displayed correctly.

## Changes

- `SoylentiClient.tsx`: Convert `aiProbability` to number before filtering
- `RumorCard.tsx`: Convert `aiProbability` to number before display logic

## Test plan

- [x] Unit tests pass
- [ ] Verify news with string probability values now display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)