### PR TITLE
fix: footer 'que no hay' text color visibility

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -316,7 +316,7 @@ export default function Layout({
                   No busques más
                 </h3>
               </div>
-              <p className="font-accent text-betis-oro/80 italic mb-3">
+              <p className="font-accent text-betis-oro italic mb-3">
                 que no hay
               </p>
               <p className="font-body text-gray-300 text-sm leading-relaxed">


### PR DESCRIPTION
## Issue

The footer text "que no hay" appears black instead of golden, making it hard to see against the dark footer background.

## Root Cause

The CSS class `text-betis-oro/80` uses Tailwind's opacity modifier syntax (`/80`), but custom colors like `betis-oro` don't support opacity modifiers unless specifically configured in the Tailwind config with color channel values.

## Solution

Changed `text-betis-oro/80` to `text-betis-oro` to use the full opacity golden color, which properly displays on the dark background.

## Changes

- **src/components/Layout.tsx** (line 319): `text-betis-oro/80` → `text-betis-oro`

## Visual Impact

The "que no hay" text in the footer will now be visible in golden color instead of appearing black.

## Testing

- ✅ Type checking passed
- ✅ Linting passed  
- ✅ No functional changes, only visual fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>