### PR TITLE
Fix high severity security vulnerability in qs package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17676,9 +17676,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {


### PR DESCRIPTION
## Security Fix

Fixes high severity security vulnerability in the `qs` package (CVE: GHSA-6rw7-vpxm-498p).

### Vulnerability Details

- **Package**: qs
- **Severity**: High
- **CVE**: GHSA-6rw7-vpxm-498p
- **Issue**: Denial of Service via memory exhaustion caused by `arrayLimit` bypass in qs package
- **Affected versions**: < 6.14.1

### Fix

Updated `qs` package from < 6.14.1 to >= 6.14.1 using `npm audit fix`.

### Verification

```bash
npm audit
# Result: 0 vulnerabilities
```

### Changes

- Updated `package-lock.json` with patched qs version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>