### PR TITLE
chore: disable scheduled news sync

### DIFF
--- a/.github/workflows/sync-rumors.yml
+++ b/.github/workflows/sync-rumors.yml
@@ -1,4 +1,4 @@
-name: Sync Rumors (Scheduled)
+name: Sync Rumors
 
 on:
   # schedule:


### PR DESCRIPTION
Commented out the hourly cron trigger. Manual trigger via workflow_dispatch still available.

https://claude.ai/code/session_01G3912B87aehBpynWYWfKZg