### PR TITLE
chore(deps): bump @clerk/nextjs to 7.2.1 and fix flaky MatchesList tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "betis",
       "version": "0.1.0",
       "dependencies": {
-        "@clerk/nextjs": "^7.0.8",
+        "@clerk/nextjs": "^7.2.1",
         "@hookform/resolvers": "^5.2.2",
         "@sentry/nextjs": "^10.47.0",
         "@supabase/supabase-js": "^2.101.1",
@@ -1897,12 +1897,12 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.10.tgz",
-      "integrity": "sha512-keu1ouU4Kz8zsmNp+JD7fXd/023ILRaMavgAcFxdwVMjBTW37SSgBqOlEKqGQ96oyi/Kg6gBdrqG/2CabluSYw==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.12.tgz",
+      "integrity": "sha512-pTuD3+3IvLrjx9XMYdbqpttTltrWc7npxkOIDzhtID5/+IOomxZAzsnxU1G1hvOeBoR1Jl68ZgKQw66aZ+DRFQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.8.0",
+        "@clerk/shared": "^4.8.2",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -1911,14 +1911,14 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.2.0.tgz",
-      "integrity": "sha512-V4dym5gvUb0MEzrYq63J+EzjPoeFIJ316KhBySWPklRjxs4wRYWqLFkQpU9RShIDibTB7BuXl1h982GYR07BFA==",
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-7.2.2.tgz",
+      "integrity": "sha512-kFQ+sXD5qAxL8C53hDgpKJT+KithlOFDlkMK5Bwv/YNFy/Sf5Tzkxdh4y/AfAgJlDU0ksvu0Hn7mtB2QT8t9bg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^3.2.10",
-        "@clerk/react": "^6.4.0",
-        "@clerk/shared": "^4.8.0",
+        "@clerk/backend": "^3.2.12",
+        "@clerk/react": "^6.4.2",
+        "@clerk/shared": "^4.8.2",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -1932,12 +1932,12 @@
       }
     },
     "node_modules/@clerk/react": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.4.0.tgz",
-      "integrity": "sha512-AdDWW5K67PDjXphZc1iATC7vJEVsj0zLQiybImGmYAZQTZMoZCfVaWq2M+FqQwRB0O9iZsu0K/6rT9vawC4pIA==",
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@clerk/react/-/react-6.4.2.tgz",
+      "integrity": "sha512-l43pon5wcM0n4e3gnRP7MWdvAXAa3M7BOF6aeNwEuITxgy6MU6ypej9tPeGmXxPicL/Hd6E/VRgiEipEKDqyCQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.8.0",
+        "@clerk/shared": "^4.8.2",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -1949,9 +1949,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.0.tgz",
-      "integrity": "sha512-RLIs8gqSmciALkJ5caAed0+Xb38b0itW+lTwhZ2arqOcbY/nfJboZbfXKU5VDUbs4ivMD0xKKy6tHQTbpKgqmA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.8.2.tgz",
+      "integrity": "sha512-kBFDNeLdiNZkOHavTkOB00NMuqsmOGgVtDlzCS0/yivxsCUZXk3AT6+UsTfeSBGV7QD80YxjeFMNSrpqnSv4Gg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "prepare": "lefthook install"
   },
   "dependencies": {
-    "@clerk/nextjs": "^7.0.8",
+    "@clerk/nextjs": "^7.2.1",
     "@hookform/resolvers": "^5.2.2",
     "@sentry/nextjs": "^10.47.0",
     "@supabase/supabase-js": "^2.101.1",

--- a/tests/unit/components/admin/MatchesList.test.tsx
+++ b/tests/unit/components/admin/MatchesList.test.tsx
@@ -222,9 +222,12 @@ describe('MatchesList', () => {
     fireEvent.click(deleteButtons[0]);
 
     expect(global.confirm).toHaveBeenCalledWith('¿Estás seguro de que quieres eliminar el partido contra Valencia CF?');
-    
+
     await waitFor(() => {
       expect(mockOnDelete).toHaveBeenCalledWith(1);
+    });
+    await waitFor(() => {
+      expect(deleteButtons[0]).not.toBeDisabled();
     });
   });
 
@@ -262,6 +265,9 @@ describe('MatchesList', () => {
     await waitFor(() => {
       expect(global.alert).toHaveBeenCalledWith('Error al eliminar: Database error');
     });
+    await waitFor(() => {
+      expect(deleteButtons[0]).not.toBeDisabled();
+    });
   });
 
   it('should call onSync when sync button is clicked and confirmed', async () => {
@@ -280,9 +286,12 @@ describe('MatchesList', () => {
     fireEvent.click(syncButtons[0]); // First match has external_id
 
     expect(global.confirm).toHaveBeenCalledWith('¿Estás seguro de que quieres sincronizar el partido contra Valencia CF?');
-    
+
     await waitFor(() => {
       expect(mockOnSync).toHaveBeenCalledWith(12345);
+    });
+    await waitFor(() => {
+      expect(syncButtons[0]).not.toBeDisabled();
     });
   });
 
@@ -316,6 +325,9 @@ describe('MatchesList', () => {
 
     await waitFor(() => {
       expect(global.alert).toHaveBeenCalledWith('Error al sincronizar: API error');
+    });
+    await waitFor(() => {
+      expect(syncButtons[0]).not.toBeDisabled();
     });
   });
 
@@ -409,6 +421,12 @@ describe('MatchesList', () => {
     await waitFor(() => {
       expect(deleteButtons[0]).toBeDisabled();
     });
+    // Wait for the async operation's finally block to complete so no state
+    // updates remain pending after the test ends (React 19 + jsdom teardown
+    // otherwise logs an unhandled rejection from dispatchSetState).
+    await waitFor(() => {
+      expect(deleteButtons[0]).not.toBeDisabled();
+    });
   });
 
   it('should disable sync button while syncing', async () => {
@@ -429,6 +447,9 @@ describe('MatchesList', () => {
     // Button should be disabled during sync
     await waitFor(() => {
       expect(syncButtons[0]).toBeDisabled();
+    });
+    await waitFor(() => {
+      expect(syncButtons[0]).not.toBeDisabled();
     });
   });
 });

--- a/tests/unit/components/admin/MatchesList.test.tsx
+++ b/tests/unit/components/admin/MatchesList.test.tsx
@@ -1,60 +1,60 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import MatchesList from '@/components/admin/MatchesList';
-import { Match } from '@/lib/api/supabase';
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import MatchesList from "@/components/admin/MatchesList";
+import { Match } from "@/lib/api/supabase";
 
 // Mock date-fns
-vi.mock('date-fns', () => ({
+vi.mock("date-fns", () => ({
   format: vi.fn((date, formatStr) => {
-    if (formatStr === 'dd/MM/yyyy') return '15/08/2024';
-    if (formatStr === 'HH:mm') return '20:00';
+    if (formatStr === "dd/MM/yyyy") return "15/08/2024";
+    if (formatStr === "HH:mm") return "20:00";
     return date.toString();
-  })
+  }),
 }));
 
-vi.mock('date-fns/locale', () => ({
-  es: {}
+vi.mock("date-fns/locale", () => ({
+  es: {},
 }));
 
 // Mock window.confirm and alert
 global.confirm = vi.fn(() => true);
 global.alert = vi.fn();
 
-describe('MatchesList', () => {
+describe("MatchesList", () => {
   const mockMatches: Match[] = [
     {
       id: 1,
-      opponent: 'Valencia CF',
-      competition: 'LaLiga',
-      home_away: 'home',
-      date_time: '2024-08-15T20:00:00Z',
-      notes: 'Important match',
+      opponent: "Valencia CF",
+      competition: "LaLiga",
+      home_away: "home",
+      date_time: "2024-08-15T20:00:00Z",
+      notes: "Important match",
       external_id: 12345,
-      created_at: '2024-01-01T00:00:00Z',
-      updated_at: '2024-01-01T00:00:00Z'
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
     },
     {
       id: 2,
-      opponent: 'Real Madrid',
-      competition: 'Copa del Rey',
-      home_away: 'away',
-      date_time: '2024-08-20T18:30:00Z',
-      notes: 'Classic match',
+      opponent: "Real Madrid",
+      competition: "Copa del Rey",
+      home_away: "away",
+      date_time: "2024-08-20T18:30:00Z",
+      notes: "Classic match",
       external_id: 12346,
-      created_at: '2024-01-01T00:00:00Z',
-      updated_at: '2024-01-01T00:00:00Z'
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
     },
     {
       id: 3,
-      opponent: 'Barcelona',
-      competition: 'LaLiga',
-      home_away: 'home',
-      date_time: '2024-08-25T21:00:00Z',
+      opponent: "Barcelona",
+      competition: "LaLiga",
+      home_away: "home",
+      date_time: "2024-08-25T21:00:00Z",
       notes: undefined,
       external_id: undefined,
-      created_at: '2024-01-01T00:00:00Z',
-      updated_at: '2024-01-01T00:00:00Z'
-    }
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
+    },
   ];
 
   const mockOnEdit = vi.fn();
@@ -67,147 +67,147 @@ describe('MatchesList', () => {
     global.alert = vi.fn();
   });
 
-  it('should render the component with matches', () => {
+  it("should render the component with matches", () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onSync={mockOnSync}
-      />
+      />,
     );
 
-    expect(screen.getByText('Gestión de Partidos')).toBeInTheDocument();
-    expect(screen.getByText('Total: 3 partidos')).toBeInTheDocument();
-    expect(screen.getByText('Valencia CF')).toBeInTheDocument();
-    expect(screen.getByText('Real Madrid')).toBeInTheDocument();
-    expect(screen.getByText('Barcelona')).toBeInTheDocument();
+    expect(screen.getByText("Gestión de Partidos")).toBeInTheDocument();
+    expect(screen.getByText("Total: 3 partidos")).toBeInTheDocument();
+    expect(screen.getByText("Valencia CF")).toBeInTheDocument();
+    expect(screen.getByText("Real Madrid")).toBeInTheDocument();
+    expect(screen.getByText("Barcelona")).toBeInTheDocument();
   });
 
-  it('should render filters', () => {
+  it("should render filters", () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    expect(screen.getByLabelText('Buscar')).toBeInTheDocument();
-    expect(screen.getByLabelText('Competición')).toBeInTheDocument();
-    expect(screen.getByLabelText('Local/Visitante')).toBeInTheDocument();
+    expect(screen.getByLabelText("Buscar")).toBeInTheDocument();
+    expect(screen.getByLabelText("Competición")).toBeInTheDocument();
+    expect(screen.getByLabelText("Local/Visitante")).toBeInTheDocument();
   });
 
-  it('should filter matches by search text', async () => {
+  it("should filter matches by search text", async () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const searchInput = screen.getByLabelText('Buscar');
-    fireEvent.change(searchInput, { target: { value: 'Valencia' } });
+    const searchInput = screen.getByLabelText("Buscar");
+    fireEvent.change(searchInput, { target: { value: "Valencia" } });
 
     await waitFor(() => {
-      expect(screen.getByText('Total: 1 partidos')).toBeInTheDocument();
-      expect(screen.getByText('Valencia CF')).toBeInTheDocument();
-      expect(screen.queryByText('Real Madrid')).not.toBeInTheDocument();
+      expect(screen.getByText("Total: 1 partidos")).toBeInTheDocument();
+      expect(screen.getByText("Valencia CF")).toBeInTheDocument();
+      expect(screen.queryByText("Real Madrid")).not.toBeInTheDocument();
     });
   });
 
-  it('should filter matches by competition', async () => {
+  it("should filter matches by competition", async () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const competitionSelect = screen.getByLabelText('Competición');
-    fireEvent.change(competitionSelect, { target: { value: 'LaLiga' } });
+    const competitionSelect = screen.getByLabelText("Competición");
+    fireEvent.change(competitionSelect, { target: { value: "LaLiga" } });
 
     await waitFor(() => {
-      expect(screen.getByText('Total: 2 partidos')).toBeInTheDocument();
-      expect(screen.getByText('Valencia CF')).toBeInTheDocument();
-      expect(screen.getByText('Barcelona')).toBeInTheDocument();
-      expect(screen.queryByText('Real Madrid')).not.toBeInTheDocument();
+      expect(screen.getByText("Total: 2 partidos")).toBeInTheDocument();
+      expect(screen.getByText("Valencia CF")).toBeInTheDocument();
+      expect(screen.getByText("Barcelona")).toBeInTheDocument();
+      expect(screen.queryByText("Real Madrid")).not.toBeInTheDocument();
     });
   });
 
-  it('should filter matches by home/away', async () => {
+  it("should filter matches by home/away", async () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const homeAwaySelect = screen.getByLabelText('Local/Visitante');
-    fireEvent.change(homeAwaySelect, { target: { value: 'away' } });
+    const homeAwaySelect = screen.getByLabelText("Local/Visitante");
+    fireEvent.change(homeAwaySelect, { target: { value: "away" } });
 
     await waitFor(() => {
-      expect(screen.getByText('Total: 1 partidos')).toBeInTheDocument();
-      expect(screen.getByText('Real Madrid')).toBeInTheDocument();
-      expect(screen.queryByText('Valencia CF')).not.toBeInTheDocument();
+      expect(screen.getByText("Total: 1 partidos")).toBeInTheDocument();
+      expect(screen.getByText("Real Madrid")).toBeInTheDocument();
+      expect(screen.queryByText("Valencia CF")).not.toBeInTheDocument();
     });
   });
 
-  it('should sort matches by opponent', () => {
+  it("should sort matches by opponent", () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const opponentHeader = screen.getByText('Oponente');
+    const opponentHeader = screen.getByText("Oponente");
     fireEvent.click(opponentHeader);
 
     // Check that matches are sorted - Barcelona should come first alphabetically
-    const matchRows = screen.getAllByRole('row');
-    expect(matchRows[1]).toHaveTextContent('Barcelona'); // First data row
+    const matchRows = screen.getAllByRole("row");
+    expect(matchRows[1]).toHaveTextContent("Barcelona"); // First data row
   });
 
-  it('should handle sorting direction change', () => {
+  it("should handle sorting direction change", () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const opponentHeader = screen.getByText('Oponente');
-    
+    const opponentHeader = screen.getByText("Oponente");
+
     // Click twice to change from asc to desc
     fireEvent.click(opponentHeader);
     fireEvent.click(opponentHeader);
 
     // Check sort direction icon
-    expect(screen.getByText('↙️')).toBeInTheDocument();
+    expect(screen.getByText("↙️")).toBeInTheDocument();
   });
 
-  it('should call onEdit when edit button is clicked', () => {
+  it("should call onEdit when edit button is clicked", () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const editButtons = screen.getAllByText('✏️ Editar');
+    const editButtons = screen.getAllByText("✏️ Editar");
     fireEvent.click(editButtons[0]);
 
     expect(mockOnEdit).toHaveBeenCalledWith(mockMatches[0]);
   });
 
-  it('should call onDelete when delete is confirmed', async () => {
+  it("should call onDelete when delete is confirmed", async () => {
     mockOnDelete.mockResolvedValue({ success: true });
 
     render(
@@ -215,13 +215,15 @@ describe('MatchesList', () => {
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const deleteButtons = screen.getAllByText('🗑️ Eliminar');
+    const deleteButtons = screen.getAllByText("🗑️ Eliminar");
     fireEvent.click(deleteButtons[0]);
 
-    expect(global.confirm).toHaveBeenCalledWith('¿Estás seguro de que quieres eliminar el partido contra Valencia CF?');
+    expect(global.confirm).toHaveBeenCalledWith(
+      "¿Estás seguro de que quieres eliminar el partido contra Valencia CF?",
+    );
 
     await waitFor(() => {
       expect(mockOnDelete).toHaveBeenCalledWith(1);
@@ -231,7 +233,7 @@ describe('MatchesList', () => {
     });
   });
 
-  it('should not call onDelete when delete is cancelled', () => {
+  it("should not call onDelete when delete is cancelled", () => {
     global.confirm = vi.fn(() => false);
 
     render(
@@ -239,38 +241,40 @@ describe('MatchesList', () => {
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const deleteButtons = screen.getAllByText('🗑️ Eliminar');
+    const deleteButtons = screen.getAllByText("🗑️ Eliminar");
     fireEvent.click(deleteButtons[0]);
 
     expect(mockOnDelete).not.toHaveBeenCalled();
   });
 
-  it('should handle delete error', async () => {
-    mockOnDelete.mockResolvedValue({ success: false, error: 'Database error' });
+  it("should handle delete error", async () => {
+    mockOnDelete.mockResolvedValue({ success: false, error: "Database error" });
 
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const deleteButtons = screen.getAllByText('🗑️ Eliminar');
+    const deleteButtons = screen.getAllByText("🗑️ Eliminar");
     fireEvent.click(deleteButtons[0]);
 
     await waitFor(() => {
-      expect(global.alert).toHaveBeenCalledWith('Error al eliminar: Database error');
+      expect(global.alert).toHaveBeenCalledWith(
+        "Error al eliminar: Database error",
+      );
     });
     await waitFor(() => {
       expect(deleteButtons[0]).not.toBeDisabled();
     });
   });
 
-  it('should call onSync when sync button is clicked and confirmed', async () => {
+  it("should call onSync when sync button is clicked and confirmed", async () => {
     mockOnSync.mockResolvedValue({ success: true });
 
     render(
@@ -279,13 +283,15 @@ describe('MatchesList', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onSync={mockOnSync}
-      />
+      />,
     );
 
-    const syncButtons = screen.getAllByText('🔄 Sincronizar');
+    const syncButtons = screen.getAllByText("🔄 Sincronizar");
     fireEvent.click(syncButtons[0]); // First match has external_id
 
-    expect(global.confirm).toHaveBeenCalledWith('¿Estás seguro de que quieres sincronizar el partido contra Valencia CF?');
+    expect(global.confirm).toHaveBeenCalledWith(
+      "¿Estás seguro de que quieres sincronizar el partido contra Valencia CF?",
+    );
 
     await waitFor(() => {
       expect(mockOnSync).toHaveBeenCalledWith(12345);
@@ -295,21 +301,21 @@ describe('MatchesList', () => {
     });
   });
 
-  it('should not show sync button for matches without external_id', () => {
+  it("should not show sync button for matches without external_id", () => {
     render(
       <MatchesList
         matches={[mockMatches[2]]} // Barcelona match has no external_id
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onSync={mockOnSync}
-      />
+      />,
     );
 
-    expect(screen.queryByText('🔄 Sincronizar')).not.toBeInTheDocument();
+    expect(screen.queryByText("🔄 Sincronizar")).not.toBeInTheDocument();
   });
 
-  it('should handle sync error', async () => {
-    mockOnSync.mockResolvedValue({ success: false, error: 'API error' });
+  it("should handle sync error", async () => {
+    mockOnSync.mockResolvedValue({ success: false, error: "API error" });
 
     render(
       <MatchesList
@@ -317,53 +323,51 @@ describe('MatchesList', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onSync={mockOnSync}
-      />
+      />,
     );
 
-    const syncButtons = screen.getAllByText('🔄 Sincronizar');
+    const syncButtons = screen.getAllByText("🔄 Sincronizar");
     fireEvent.click(syncButtons[0]);
 
     await waitFor(() => {
-      expect(global.alert).toHaveBeenCalledWith('Error al sincronizar: API error');
+      expect(global.alert).toHaveBeenCalledWith(
+        "Error al sincronizar: API error",
+      );
     });
     await waitFor(() => {
       expect(syncButtons[0]).not.toBeDisabled();
     });
   });
 
-  it('should show loading state', () => {
+  it("should show loading state", () => {
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         isLoading={true}
-      />
+      />,
     );
 
     // Loading state may be handled by the parent component
-    expect(screen.getByText('Gestión de Partidos')).toBeInTheDocument();
+    expect(screen.getByText("Gestión de Partidos")).toBeInTheDocument();
   });
 
-  it('should show empty state when no matches', () => {
+  it("should show empty state when no matches", () => {
     render(
-      <MatchesList
-        matches={[]}
-        onEdit={mockOnEdit}
-        onDelete={mockOnDelete}
-      />
+      <MatchesList matches={[]} onEdit={mockOnEdit} onDelete={mockOnDelete} />,
     );
 
-    expect(screen.getByText('Total: 0 partidos')).toBeInTheDocument();
+    expect(screen.getByText("Total: 0 partidos")).toBeInTheDocument();
   });
 
-  it('should handle pagination', () => {
+  it("should handle pagination", () => {
     const manyMatches = Array.from({ length: 25 }, (_, i) => ({
       ...mockMatches[0],
       id: i + 1,
       opponent: `Team ${i + 1}`,
-      created_at: '2024-01-01T00:00:00Z',
-      updated_at: '2024-01-01T00:00:00Z'
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
     }));
 
     render(
@@ -371,21 +375,21 @@ describe('MatchesList', () => {
         matches={manyMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
     // Should show page navigation
-    expect(screen.getByText('Página 1 de 3')).toBeInTheDocument();
-    expect(screen.getByText('Siguiente')).toBeInTheDocument();
+    expect(screen.getByText("Página 1 de 3")).toBeInTheDocument();
+    expect(screen.getByText("Siguiente")).toBeInTheDocument();
   });
 
-  it('should navigate between pages', () => {
+  it("should navigate between pages", () => {
     const manyMatches = Array.from({ length: 25 }, (_, i) => ({
       ...mockMatches[0],
       id: i + 1,
       opponent: `Team ${i + 1}`,
-      created_at: '2024-01-01T00:00:00Z',
-      updated_at: '2024-01-01T00:00:00Z'
+      created_at: "2024-01-01T00:00:00Z",
+      updated_at: "2024-01-01T00:00:00Z",
     }));
 
     render(
@@ -393,28 +397,33 @@ describe('MatchesList', () => {
         matches={manyMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const nextButton = screen.getByText('Siguiente');
+    const nextButton = screen.getByText("Siguiente");
     fireEvent.click(nextButton);
 
-    expect(screen.getByText('Página 2 de 3')).toBeInTheDocument();
-    expect(screen.getByText('Team 11')).toBeInTheDocument(); // First item on page 2
+    expect(screen.getByText("Página 2 de 3")).toBeInTheDocument();
+    expect(screen.getByText("Team 11")).toBeInTheDocument(); // First item on page 2
   });
 
-  it('should disable delete button while deleting', async () => {
-    mockOnDelete.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({ success: true }), 100)));
+  it("should disable delete button while deleting", async () => {
+    mockOnDelete.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ success: true }), 100),
+        ),
+    );
 
     render(
       <MatchesList
         matches={mockMatches}
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
-      />
+      />,
     );
 
-    const deleteButtons = screen.getAllByText('🗑️ Eliminar');
+    const deleteButtons = screen.getAllByText("🗑️ Eliminar");
     fireEvent.click(deleteButtons[0]);
 
     // Button should be disabled during deletion
@@ -429,8 +438,13 @@ describe('MatchesList', () => {
     });
   });
 
-  it('should disable sync button while syncing', async () => {
-    mockOnSync.mockImplementation(() => new Promise(resolve => setTimeout(() => resolve({ success: true }), 100)));
+  it("should disable sync button while syncing", async () => {
+    mockOnSync.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ success: true }), 100),
+        ),
+    );
 
     render(
       <MatchesList
@@ -438,10 +452,10 @@ describe('MatchesList', () => {
         onEdit={mockOnEdit}
         onDelete={mockOnDelete}
         onSync={mockOnSync}
-      />
+      />,
     );
 
-    const syncButtons = screen.getAllByText('🔄 Sincronizar');
+    const syncButtons = screen.getAllByText("🔄 Sincronizar");
     fireEvent.click(syncButtons[0]);
 
     // Button should be disabled during sync


### PR DESCRIPTION
Supersedes #395 (@clerk/nextjs 7.0.8 -> 7.2.1) and #396 (@clerk/shared
4.8.0 -> 4.8.2, pulled in transitively by the Clerk bump).

CI's Tests (Required) job on both dependency PRs flaked on an unhandled
ReferenceError: window is not defined thrown from React 19's
dispatchSetState during jsdom teardown. MatchesList's handleDelete and
handleSync finally-blocks dispatch setState after the tests end, so the
update runs after jsdom tears down window.

Fix the tests to await the button returning to its enabled state so the
finally block's setState completes within the test boundary.

https://claude.ai/code/session_019E3sasz9toCidoL1Et4i6v

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated @clerk/nextjs authentication library to version 7.2.1

* **Tests**
  * Enhanced test suite for admin components with improved validation of asynchronous operations, including additional verification of component state transitions during pending operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->