### PR TITLE
chore: auto-merge dependabot PRs (non-major)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge on non-major updates
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- Adds a `dependabot-auto-merge.yml` workflow that auto-enables merge on Dependabot PRs whose update-type is not `semver-major`. Major bumps remain manual.
- Pairs with `allow_auto_merge: true` at the repo level (just verified across the portfolio).
- Result: minor/patch dependabot PRs auto-merge once CI is green; major bumps stay in the queue for explicit review.

## Test plan
- [ ] Next dependabot minor/patch PR auto-merges on green
- [ ] A simulated major bump does NOT auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)