### PR TITLE
chore: add github-actions to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,3 +22,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      all-minor-and-patch:
+        applies-to: version-updates
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,8 @@ updates:
         update-types:
           - "minor"
           - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds the `github-actions` ecosystem to `.github/dependabot.yml` so the 4 existing workflow files get tracked for action-version bumps. Matches the portfolio standard (npm + github-actions). One of 4 PRs from a Dependabot config audit across the portfolio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)