### PR TITLE
docs(claude): add homepage convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -518,4 +518,4 @@ Available tools: `get_health_tier`, `get_campaign_status`, `query_portfolio`, `g
 
 When working on health improvements, check the per-repo report for the current tier checklist and use the consumer guide for fix instructions.
 
-If this repo deploys a page, set the GitHub `homepage` field to its canonical URL — that's how repo-butler surfaces the deployed link in dashboards and agent cards.
+If this repo deploys a page, set its GitHub repository Homepage URL (the Website field in the repo's About section — not `package.json`'s `homepage`) to the canonical URL. That's how repo-butler surfaces the deployed link in dashboards and agent cards.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -517,3 +517,5 @@ claude mcp add repo-butler node /path/to/repo-butler/src/mcp.js
 Available tools: `get_health_tier`, `get_campaign_status`, `query_portfolio`, `get_snapshot_diff`, `get_governance_findings`.
 
 When working on health improvements, check the per-repo report for the current tier checklist and use the consumer guide for fix instructions.
+
+If this repo deploys a page, set the GitHub `homepage` field to its canonical URL — that's how repo-butler surfaces the deployed link in dashboards and agent cards.


### PR DESCRIPTION
Adds the homepage convention from the repo-butler consumer guide:

> If this repo deploys a page, set the GitHub `homepage` field to its canonical URL — that's how repo-butler surfaces the deployed link in dashboards and agent cards.

See repo-butler PR #205 for the canonical doc update.