### PR TITLE
fix(clasificacion): force-dynamic so build doesn't call football-data API

### DIFF
--- a/src/app/clasificacion/page.tsx
+++ b/src/app/clasificacion/page.tsx
@@ -18,6 +18,12 @@ export const metadata: Metadata = {
     "Clasificación actual de La Liga Santander con la posición del Real Betis. Puntos, partidos jugados y estadísticas completas.",
 };
 
+// Render at request time. Static prerender would call football-data.org during
+// `next build`, which fails when the workflow lacks the API key — e.g. on
+// Dependabot CI runs that don't get repository secrets. Real-time standings are
+// also a better fit for a fan-facing page than build-pinned data.
+export const dynamic = "force-dynamic";
+
 import {
   getPositionStyle,
   getPositionBadge,


### PR DESCRIPTION
## Summary
- Mark `/clasificacion` as `force-dynamic` so it renders at request time instead of static-prerendering at `next build`.

## Why
Build-time prerender of `/clasificacion` calls football-data.org via `FootballDataService.getLaLigaStandings()` at module-evaluation time. When the workflow run lacks `FOOTBALL_DATA_API_KEY` (the standard Dependabot PR case), the API returns 403 and `next build` fails with `Error occurred prerendering page "/clasificacion"`. This blocks `Tests (Required)` for every open Dependabot PR (#408, #409, #410, #411, #413, #414).

Switching to dynamic rendering means each visitor request triggers a fresh standings fetch — appropriate for a fan-facing page where current data matters more than build-pinned data, and also aligns with the same pattern the rest of the dynamic routes already use.

Trade-off: visitor TTFB picks up the football-data round-trip (~200-500ms cached at the CDN layer via Vercel). Acceptable for a low-traffic supporters' site.

## Test plan
- [ ] CI passes on this PR.
- [ ] After merge, `@dependabot rebase` on each open Dependabot PR; confirm `Tests (Required)` flips to pass and auto-merge fires.
