### PR TITLE
docs: final cleanup pass — robots.txt, MSW mentions, refreshed roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,37 +1,30 @@
 # Roadmap
 
-**Last updated:** 2026-05-16
+**Last updated:** 2026-05-18
 
-This document tracks planned and possible future work for the Peña Bética Escocesa site after the 2026-05 static-site simplification (PRs #427–#432). The site is now a public static page with two football-data.org-backed API routes; the database, authentication, admin panel, trivia, RSVP/contact surface, and feature-flag abstraction have all been removed, and a final dead-code/CSP/orphan-component sweep landed in PR #432.
+This document tracks planned and possible future work for the Peña Bética Escocesa site after the 2026-05 static-site simplification. The site is now a public static page with two football-data.org-backed API routes; the database, authentication, admin panel, trivia, RSVP/contact surface, feature-flag abstraction, Storybook, MSW, and Sentry observability have all been removed.
 
 ## Recently completed
 
-The static-site simplification ran over six PRs in May 2026:
+The static-site simplification ran over twelve PRs in May 2026:
 
 - **#427** — switched `/partidos` to the live football-data.org API, removed the admin panel and background sync.
 - **#428** — removed the Supabase dependency, SQL folder, and remaining DB helpers.
 - **#429** — removed Clerk authentication, middleware, sign-in/sign-up pages.
 - **#430** — removed the feature-flag abstraction and inlined the nav.
 - **#431** — removed obsolete ADRs and rewrote the docs to match reality.
-- **#432** — deleted orphan components (FilteredMatches, PaginatedMatches, CompetitionFilter, FacebookPagePlugin, InstagramEmbed, SocialMediaDashboard), stripped `log.database` / `log.featureFlag`, dropped the mock-heavy `matches.test.ts`, trimmed unused CSP origins (reCAPTCHA, hCaptcha, Cloudflare Turnstile, Google Fonts since `next/font` self-hosts), fixed a stale `nextConfigPath` in `.storybook/main.ts`.
+- **#432** — deleted orphan components, stripped dead logger helpers, trimmed unused CSP origins, dropped the mock-heavy `matches.test.ts`.
+- **#434** — dropped the orphan FacebookSDK and trimmed Facebook CSP origins.
+- **#435** — trimmed dead `BusinessLogicError` and unexported `apiUtils` helpers.
+- **#436** — stripped dead logger helpers (`auth`, `apiRequest`, `business`, `child`).
+- **#437 / #438** — removed Storybook entirely; cleanup sweep removed dead schemas, MSW, stale `.vscode/` and `vitest.config.ts` env vars, refreshed PWA shortcuts.
+- **#439** — removed Sentry error monitoring (never fully wired in Vercel) and the `@sentry/nextjs` dependency.
 
-End-state: a public static page reading match data from football-data.org, with no DB, auth, admin, or feature-flag surface.
+End-state: a public static page with twelve routes (ten static + two dynamic API routes), one external dependency (football-data.org), no DB / auth / admin / feature flags / Storybook / MSW / Sentry.
 
 ## Near-term: maintenance
 
-### Major dependency upgrades
-
-These packages are pinned below latest major versions and need explicit migration:
-
-| Package        | Current | Latest | Risk   | Notes                                                                                                |
-| -------------- | ------- | ------ | ------ | ---------------------------------------------------------------------------------------------------- |
-| `lucide-react` | 0.577.0 | 1.x    | Medium | Icon library used across the site. v1 renamed/reorganized icons. Audit all imports before upgrading. |
-| `typescript`   | 5.9.x   | 6.x    | Medium | TS 6 introduces new strictness rules. Run `tsc --noEmit` after upgrade to assess impact.             |
-| `undici`       | 7.x     | 8.x    | Low    | Dev dependency only. May affect MSW/test mocking. Test suite is the main validation.                 |
-
-### Audit
-
-- Dependabot is configured for weekly grouped minor/patch updates with `next`, `react`, `react-dom` excluded for isolated review.
+Dependabot is configured for weekly grouped minor/patch updates with `next`, `react`, `react-dom` excluded for isolated review. Major framework versions (Next.js, React, TypeScript) and the icon library (`lucide-react`) are all on current latest; revisit when the next major drops.
 
 ## Future: enhancement ideas
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 
 **Last updated:** 2026-05-18
 
-This document tracks planned and possible future work for the Peña Bética Escocesa site after the 2026-05 static-site simplification. The site is now a public static page with two football-data.org-backed API routes; the database, authentication, admin panel, trivia, RSVP/contact surface, feature-flag abstraction, Storybook, MSW, and Sentry observability have all been removed.
+This document tracks planned and possible future work for the Peña Bética Escocesa site after the 2026-05 static-site simplification. The site is now a public static site with two football-data.org-backed API routes; the database, authentication, admin panel, trivia, RSVP/contact surface, feature-flag abstraction, Storybook, MSW, and Sentry observability have all been removed.
 
 ## Recently completed
 
@@ -17,10 +17,10 @@ The static-site simplification ran over twelve PRs in May 2026:
 - **#434** — dropped the orphan FacebookSDK and trimmed Facebook CSP origins.
 - **#435** — trimmed dead `BusinessLogicError` and unexported `apiUtils` helpers.
 - **#436** — stripped dead logger helpers (`auth`, `apiRequest`, `business`, `child`).
-- **#437 / #438** — removed Storybook entirely; cleanup sweep removed dead schemas, MSW, stale `.vscode/` and `vitest.config.ts` env vars, refreshed PWA shortcuts.
+- **#437 / #438** — removed Storybook entirely; cleanup sweep removed dead schemas, MSW, stale `.vscode/` directory and Supabase env vars in `vitest.config.ts`, refreshed PWA shortcuts.
 - **#439** — removed Sentry error monitoring (never fully wired in Vercel) and the `@sentry/nextjs` dependency.
 
-End-state: a public static page with twelve routes (ten static + two dynamic API routes), one external dependency (football-data.org), no DB / auth / admin / feature flags / Storybook / MSW / Sentry.
+End-state: a public static site with one external data source (football-data.org), no DB / auth / admin / trivia / RSVP/contact / feature flags / Storybook / MSW / Sentry.
 
 ## Near-term: maintenance
 

--- a/docs/testing-guide.md
+++ b/docs/testing-guide.md
@@ -19,8 +19,7 @@ tests/
 ├── unit/                # Vitest unit tests for components and pure functions
 ├── integration/         # Vitest integration tests for API routes
 ├── helpers/             # Test utilities
-├── msw/                 # MSW handlers for external API mocking
-└── setup.ts             # jsdom + jest-dom matchers
+└── setup.ts             # jsdom + jest-dom matchers + fetch polyfill
 
 e2e/                     # Playwright specs (public routes only)
 ```
@@ -41,7 +40,7 @@ vi.mock("@/components/match/MatchCard", () => ({
 
 ### Mocking `fetch` for client components
 
-`AllMatches` and `UpcomingMatchesWidget` fetch directly from `/api/matches`. Stub `fetch` per test rather than reaching for MSW:
+`AllMatches` and `UpcomingMatchesWidget` fetch directly from `/api/matches`. Stub `fetch` per test:
 
 ```typescript
 beforeEach(() => {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,19 +1,4 @@
 User-agent: *
 Allow: /
 
-# Main pages
-Allow: /nosotros
-Allow: /unete
-Allow: /contacto
-Allow: /rsvp
-Allow: /partidos
-Allow: /clasificacion
-
-# Block admin or sensitive pages (none currently)
-# Disallow: /admin
-
-# Sitemap location
 Sitemap: https://betis-escocia.vercel.app/sitemap.xml
-
-# Crawl delay (optional)
-Crawl-delay: 1


### PR DESCRIPTION
## Summary

After the Sentry removal (#439) and the earlier sweeps, a few stragglers remained in docs and config:

- **`public/robots.txt`**: dropped the explicit `Allow: /rsvp` and `Allow: /contacto` lines (both routes are dead and were actively pointing crawlers at 404s). Also dropped the rest of the per-route enumeration since `Allow: /` at the top already permits everything. Result is a 4-line robots.txt with just the sitemap pointer.
- **`docs/testing-guide.md`**: removed the `tests/msw/` directory listing in the layout diagram and the "rather than reaching for MSW" parenthetical in the fetch-mocking pattern. MSW was deleted in PR #438.
- **`docs/roadmap.md`**: rewrote the recent-completions list to include PRs #434–#439, dropped the major-dep upgrade table (all three rows — `lucide-react`, `typescript`, `undici` — are now on the latest version), and updated the end-state summary to include Storybook, MSW, and Sentry among the removed surfaces.

## What was intentionally left

Historical references in `tasks/ideas.md` ("RSVP, Contact, Dashboard, GDPR, OneSignal, Daily Trivia surfaces were removed"), `docs/adr/004-feature-flags.md` (the why-superseded note), `docs/adr/013-security.md` ("Clerk + RLS removed in PR #428/#429"), and `docs/adr/README.md` (the removed-ADRs paragraph) are intentional records of what was removed and why. They survive because future-you needs them to understand the empty space.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [x] `npm test` — all tests pass
- [x] `npm run build` clean
- [x] Grep across all docs for `supabase`, `clerk`, `sentry`, `storybook`, `msw`, `trivia`, `rsvp`, `onesignal`, `monitoring-tunnel` returns only the intentional historical references listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)