### PR TITLE
fix: register brand colours in @theme so hover/focus variants work project-wide

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -30,14 +30,14 @@ export default function Error({
         <div className="space-y-4">
           <button
             onClick={() => reset()}
-            className="inline-block bg-betis-verde text-white px-6 py-3 rounded-lg font-semibold hover:bg-[var(--betis-verde-dark)] transition-colors mr-4"
+            className="inline-block bg-betis-verde text-white px-6 py-3 rounded-lg font-semibold hover:bg-betis-verde-dark transition-colors mr-4"
           >
             Intentar de nuevo
           </button>
 
           <Link
             href="/"
-            className="inline-block bg-gray-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-[var(--betis-verde-dark)] transition-colors"
+            className="inline-block bg-gray-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-betis-verde-dark transition-colors"
           >
             Volver al inicio
           </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,35 @@
 @import "tailwindcss";
 
+/* Register brand-color CSS variables as Tailwind v4 theme colors so
+ * modifier variants (hover:, focus:, group-hover:, etc.) are generated
+ * for every utility shape (bg-, text-, border-, ring-, from-, to-, ...).
+ * Without this block, only the static utility classes defined further
+ * below work, and any `hover:bg-betis-verde-dark` etc. silently no-ops.
+ */
+@theme inline {
+  --color-betis-verde: var(--betis-verde);
+  --color-betis-verde-dark: var(--betis-verde-dark);
+  --color-betis-verde-light: var(--betis-verde-light);
+  --color-betis-verde-pale: var(--betis-verde-pale);
+  --color-betis-oro: var(--betis-oro);
+  --color-betis-oro-dark: var(--betis-oro-dark);
+  --color-betis-oro-light: var(--betis-oro-light);
+  --color-betis-dark: var(--betis-dark);
+  --color-scotland-navy: var(--scotland-navy);
+  --color-scotland-blue: var(--scotland-blue);
+  --color-canvas-warm: var(--canvas-warm);
+  --color-oro-bright: var(--oro-bright);
+  --color-oro-antique: var(--oro-antique);
+
+  /* Legacy aliases — kept until call sites migrate to the canonical names */
+  --color-betis-green: var(--betis-verde);
+  --color-betis-green-dark: var(--betis-verde-dark);
+  --color-betis-green-light: var(--betis-verde-light);
+  --color-betis-gold: var(--betis-oro);
+  --color-betis-gold-dark: var(--betis-oro-dark);
+  --color-betis-black: var(--betis-negro);
+}
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -14,6 +14,8 @@
   --color-betis-oro: var(--betis-oro);
   --color-betis-oro-dark: var(--betis-oro-dark);
   --color-betis-oro-light: var(--betis-oro-light);
+  --color-betis-blanco: var(--betis-blanco);
+  --color-betis-negro: var(--betis-negro);
   --color-betis-dark: var(--betis-dark);
   --color-scotland-navy: var(--scotland-navy);
   --color-scotland-blue: var(--scotland-blue);


### PR DESCRIPTION
## Summary

Root-cause fix for the hover-variants-don't-fire bug that PR #441 worked around in one file. Adding a single `@theme inline { ... }` block to `globals.css` repairs the broken modifier variants across the entire codebase in one change.

## The bug, properly diagnosed

PR #441 fixed `src/app/error.tsx` by switching to the arbitrary-value form (`hover:bg-[var(--betis-verde-dark)]`). The bots flagged it correctly: Tailwind v4 doesn't generate `hover:` variants for class names it doesn't know about, and with no `@theme` block and no `tailwind.config.*` file, it didn't know about any of the brand tokens. The static `.bg-betis-verde` class worked because globals.css defines it as a plain CSS class further down, but every `hover:bg-betis-verde-dark`, `focus:ring-betis-verde`, `group-hover:text-betis-verde-dark`, etc. silently no-op'd.

A grep across `src/` found this pattern in ~20 files: `clasificacion`, `unete`, `jugadores-historicos`, `joaquin`, `global-error.tsx`, `ShareMatch.tsx`, `UpcomingMatchesWidget.tsx`, `AllMatches.tsx`, `Header.tsx`, `Footer.tsx`, `FeatureCard.tsx`, `Hero.tsx`, `HeroCommunity.tsx`, `ClassificationWidget.tsx`, `BetisPositionWidget.tsx`, `Field.tsx`, and `designSystem.ts`. None of the hovers, focus rings, or group-hover transitions on brand colours were actually firing.

## The fix

One `@theme inline { ... }` block at the top of `globals.css` that maps every brand-colour CSS variable to a Tailwind v4 theme colour:

\`\`\`css
@theme inline {
  --color-betis-verde: var(--betis-verde);
  --color-betis-verde-dark: var(--betis-verde-dark);
  ...
  /* Legacy aliases for backwards compatibility */
  --color-betis-green: var(--betis-verde);
  --color-betis-gold: var(--betis-oro);
  --color-betis-black: var(--betis-negro);
}
\`\`\`

Tailwind v4 now generates `hover:`, `focus:`, `group-hover:`, `active:`, etc. variants for every shape (`bg-`, `text-`, `border-`, `ring-`, `from-`, `to-`, ...) automatically. Zero per-file changes needed.

Also reverts the two arbitrary-value lines in `src/app/error.tsx` back to the canonical `hover:bg-betis-verde-dark` form now that it works correctly — keeps `error.tsx` consistent with `global-error.tsx` and the rest of the codebase.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [x] `npm test` — all 59 files / 1186 tests pass
- [x] `npm run build` clean
- [ ] Vercel preview deploy: visually confirm hovers fire on the homepage's CTA, on `/clasificacion`'s "Ver clasificación" button, and on `/unete`'s join buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)