### PR TITLE
fix: darken hover:text-betis-verde on light backgrounds

### DIFF
--- a/src/app/jugadores-historicos/page.tsx
+++ b/src/app/jugadores-historicos/page.tsx
@@ -41,9 +41,7 @@ function PlayerCardDetails({ player }: { player: Player }) {
       {player.stats && (
         <div className="flex items-center gap-2">
           <BarChart3 className="h-4 w-4 text-gray-400 flex-shrink-0" />
-          <p className="font-heading text-xs text-gray-500">
-            {player.stats}
-          </p>
+          <p className="font-heading text-xs text-gray-500">{player.stats}</p>
         </div>
       )}
 

--- a/src/app/jugadores-historicos/page.tsx
+++ b/src/app/jugadores-historicos/page.tsx
@@ -217,7 +217,7 @@ export default function JugadoresHistoricos() {
               className={`px-4 py-2 rounded-full font-heading font-bold text-sm transition-all duration-200 ${
                 activeEra === ALL_FILTER
                   ? "bg-betis-verde text-white shadow-lg"
-                  : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde hover:text-betis-verde"
+                  : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde hover:text-betis-verde-dark"
               }`}
             >
               Todos{" "}
@@ -232,7 +232,7 @@ export default function JugadoresHistoricos() {
                 className={`px-4 py-2 rounded-full font-heading font-bold text-sm transition-all duration-200 ${
                   activeEra === era
                     ? "bg-betis-verde text-white shadow-lg"
-                    : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde hover:text-betis-verde"
+                    : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde hover:text-betis-verde-dark"
                 }`}
               >
                 {ERA_CONFIG[era].title}{" "}

--- a/src/app/jugadores-historicos/page.tsx
+++ b/src/app/jugadores-historicos/page.tsx
@@ -215,7 +215,7 @@ export default function JugadoresHistoricos() {
               className={`px-4 py-2 rounded-full font-heading font-bold text-sm transition-all duration-200 ${
                 activeEra === ALL_FILTER
                   ? "bg-betis-verde text-white shadow-lg"
-                  : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde hover:text-betis-verde-dark"
+                  : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde-dark hover:text-betis-verde-dark"
               }`}
             >
               Todos{" "}
@@ -230,7 +230,7 @@ export default function JugadoresHistoricos() {
                 className={`px-4 py-2 rounded-full font-heading font-bold text-sm transition-all duration-200 ${
                   activeEra === era
                     ? "bg-betis-verde text-white shadow-lg"
-                    : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde hover:text-betis-verde-dark"
+                    : "bg-white text-gray-600 border border-gray-200 hover:border-betis-verde-dark hover:text-betis-verde-dark"
                 }`}
               >
                 {ERA_CONFIG[era].title}{" "}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -165,7 +165,7 @@ export default function Home() {
               href="https://www.facebook.com/groups/beticosenescocia/"
               target="_blank"
               rel="noopener noreferrer"
-              className="group bg-white/10 backdrop-blur-md border-2 border-white/30 hover:bg-white hover:border-white px-10 py-5 rounded-2xl font-heading font-bold text-lg text-white hover:text-betis-verde transition-all duration-300 transform hover:scale-105"
+              className="group bg-white/10 backdrop-blur-md border-2 border-white/30 hover:bg-white hover:border-white px-10 py-5 rounded-2xl font-heading font-bold text-lg text-white hover:text-betis-verde-dark transition-all duration-300 transform hover:scale-105"
             >
               <span className="flex items-center gap-2">📘 Facebook</span>
             </a>

--- a/src/app/partidos/[matchId]/page.tsx
+++ b/src/app/partidos/[matchId]/page.tsx
@@ -1,31 +1,33 @@
-import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import Link from 'next/link';
-import Image from 'next/image';
-import { FootballDataService } from '@/services/footballDataService';
-import axios from 'axios';
-import { Match } from '@/types/match';
-import { ErrorBoundary } from '@/components/ErrorBoundary';
-import LoadingSpinner from '@/components/LoadingSpinner';
-import ShareMatch from '@/components/match/ShareMatch';
-import BetisLogo from '@/components/BetisLogo';
-import { Suspense } from 'react';
-import { format } from 'date-fns';
-import { es } from 'date-fns/locale';
-import { DATE_FORMAT, TIME_FORMAT } from '@/lib/constants/dateFormats';
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import Image from "next/image";
+import { FootballDataService } from "@/services/footballDataService";
+import axios from "axios";
+import { Match } from "@/types/match";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import LoadingSpinner from "@/components/LoadingSpinner";
+import ShareMatch from "@/components/match/ShareMatch";
+import BetisLogo from "@/components/BetisLogo";
+import { Suspense } from "react";
+import { format } from "date-fns";
+import { es } from "date-fns/locale";
+import { DATE_FORMAT, TIME_FORMAT } from "@/lib/constants/dateFormats";
 
 interface MatchDetailPageProps {
   params: Promise<{ matchId: string }>;
 }
 
 // Generate metadata for the page
-export async function generateMetadata({ params }: MatchDetailPageProps): Promise<Metadata> {
+export async function generateMetadata({
+  params,
+}: MatchDetailPageProps): Promise<Metadata> {
   const { matchId: matchIdString } = await params;
   const matchId = parseInt(matchIdString);
-  
+
   if (isNaN(matchId)) {
     return {
-      title: 'Partido no encontrado - Peña Bética Escocesa',
+      title: "Partido no encontrado - Peña Bética Escocesa",
     };
   }
 
@@ -35,21 +37,24 @@ export async function generateMetadata({ params }: MatchDetailPageProps): Promis
 
     if (!match) {
       return {
-        title: 'Partido no encontrado - Peña Bética Escocesa',
+        title: "Partido no encontrado - Peña Bética Escocesa",
       };
     }
 
-    const opponent = match.homeTeam.id === 90 ? match.awayTeam.name : match.homeTeam.name;
-    const matchDate = format(new Date(match.utcDate), DATE_FORMAT, { locale: es });
+    const opponent =
+      match.homeTeam.id === 90 ? match.awayTeam.name : match.homeTeam.name;
+    const matchDate = format(new Date(match.utcDate), DATE_FORMAT, {
+      locale: es,
+    });
 
     return {
       title: `Real Betis vs ${opponent} - ${matchDate} - Peña Bética Escocesa`,
       description: `Detalles del partido Real Betis vs ${opponent} del ${matchDate}. Información completa del encuentro para los aficionados béticos en Escocia.`,
     };
   } catch (error) {
-    console.error('Error generating metadata:', error);
+    console.error("Error generating metadata:", error);
     return {
-      title: 'Detalles del partido - Peña Bética Escocesa',
+      title: "Detalles del partido - Peña Bética Escocesa",
     };
   }
 }
@@ -59,49 +64,49 @@ function formatMatchDateTime(utcDate: string): { date: string; time: string } {
   const matchDate = new Date(utcDate);
   const date = format(matchDate, DATE_FORMAT, { locale: es });
   const time = format(matchDate, TIME_FORMAT, { locale: es });
-  
+
   return { date, time };
 }
 
 // Format match status in Spanish
 function formatStatus(status: string): string {
   const statusMap: Record<string, string> = {
-    'SCHEDULED': 'Programado',
-    'TIMED': 'Programado',
-    'IN_PLAY': 'En juego',
-    'PAUSED': 'Pausado',
-    'FINISHED': 'Finalizado',
-    'SUSPENDED': 'Suspendido',
-    'POSTPONED': 'Aplazado',
-    'CANCELLED': 'Cancelado',
-    'AWARDED': 'Adjudicado'
+    SCHEDULED: "Programado",
+    TIMED: "Programado",
+    IN_PLAY: "En juego",
+    PAUSED: "Pausado",
+    FINISHED: "Finalizado",
+    SUSPENDED: "Suspendido",
+    POSTPONED: "Aplazado",
+    CANCELLED: "Cancelado",
+    AWARDED: "Adjudicado",
   };
-  
+
   return statusMap[status] || status;
 }
 
 // Get status badge styles
 function getStatusStyles(status: string): string {
   switch (status) {
-    case 'FINISHED':
-      return 'bg-gray-100 text-gray-800';
-    case 'IN_PLAY':
-    case 'PAUSED':
-      return 'bg-red-100 text-red-800';
+    case "FINISHED":
+      return "bg-gray-100 text-gray-800";
+    case "IN_PLAY":
+    case "PAUSED":
+      return "bg-red-100 text-red-800";
     default:
-      return 'bg-blue-100 text-blue-800';
+      return "bg-blue-100 text-blue-800";
   }
 }
 
 // Get match result display
 function getMatchResult(match: Match): string | null {
-  if (match.status !== 'FINISHED') return null;
-  
+  if (match.status !== "FINISHED") return null;
+
   const homeScore = match.score.fullTime.home;
   const awayScore = match.score.fullTime.away;
-  
+
   if (homeScore === null || awayScore === null) return null;
-  
+
   return `${homeScore} - ${awayScore}`;
 }
 
@@ -115,7 +120,7 @@ function getOpponent(match: Match): { name: string; crest: string } {
   const opponent = isBetisHome(match) ? match.awayTeam : match.homeTeam;
   return {
     name: opponent.name,
-    crest: opponent.crest
+    crest: opponent.crest,
   };
 }
 
@@ -140,20 +145,24 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
         <nav className="mb-8" aria-label="Navegación de migas de pan">
           <ol className="flex items-center space-x-2 text-sm text-gray-600">
             <li>
-              <Link href="/" className="hover:text-betis-verde-dark transition-colors">
+              <Link
+                href="/"
+                className="hover:text-betis-verde-dark transition-colors"
+              >
                 Inicio
               </Link>
             </li>
             <li className="text-gray-400">/</li>
             <li>
-              <Link href="/partidos" className="hover:text-betis-verde-dark transition-colors">
+              <Link
+                href="/partidos"
+                className="hover:text-betis-verde-dark transition-colors"
+              >
                 Partidos
               </Link>
             </li>
             <li className="text-gray-400">/</li>
-            <li className="text-gray-900 font-medium">
-              {opponent.name}
-            </li>
+            <li className="text-gray-900 font-medium">{opponent.name}</li>
           </ol>
         </nav>
 
@@ -183,7 +192,9 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
               </div>
             </div>
             <div className="flex items-center space-x-3">
-              <div className={`inline-block px-3 py-1 rounded-full text-sm font-medium ${getStatusStyles(match.status)}`}>
+              <div
+                className={`inline-block px-3 py-1 rounded-full text-sm font-medium ${getStatusStyles(match.status)}`}
+              >
                 {formatStatus(match.status)}
               </div>
             </div>
@@ -207,12 +218,12 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
                   />
                 )}
                 <div>
-                  <h1 className={`text-xl md:text-2xl font-bold ${betisHome ? 'text-betis-verde-dark' : 'text-gray-900'}`}>
-                    {betisHome ? 'Real Betis' : opponent.name}
+                  <h1
+                    className={`text-xl md:text-2xl font-bold ${betisHome ? "text-betis-verde-dark" : "text-gray-900"}`}
+                  >
+                    {betisHome ? "Real Betis" : opponent.name}
                   </h1>
-                  <p className="text-sm text-gray-600">
-                    Local
-                  </p>
+                  <p className="text-sm text-gray-600">Local</p>
                 </div>
               </div>
             </div>
@@ -228,9 +239,7 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
                   {time}
                 </div>
               )}
-              <p className="text-sm text-gray-600 capitalize">
-                {date}
-              </p>
+              <p className="text-sm text-gray-600 capitalize">{date}</p>
             </div>
 
             {/* Visitor Team (always on right) */}
@@ -249,12 +258,12 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
                   <BetisLogo width={80} height={80} />
                 )}
                 <div>
-                  <h1 className={`text-xl md:text-2xl font-bold ${!betisHome ? 'text-betis-verde-dark' : 'text-gray-900'}`}>
-                    {betisHome ? opponent.name : 'Real Betis'}
+                  <h1
+                    className={`text-xl md:text-2xl font-bold ${!betisHome ? "text-betis-verde-dark" : "text-gray-900"}`}
+                  >
+                    {betisHome ? opponent.name : "Real Betis"}
                   </h1>
-                  <p className="text-sm text-gray-600">
-                    Visitante
-                  </p>
+                  <p className="text-sm text-gray-600">Visitante</p>
                 </div>
               </div>
             </div>
@@ -266,8 +275,18 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
               {/* Date and Time */}
               <div className="bg-gray-50 rounded-lg p-4">
                 <h3 className="font-semibold text-gray-900 mb-2 flex items-center">
-                  <svg className="w-5 h-5 mr-2 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+                  <svg
+                    className="w-5 h-5 mr-2 text-gray-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    />
                   </svg>
                   Fecha y Hora
                 </h3>
@@ -278,17 +297,34 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
               {/* Stadium */}
               <div className="bg-gray-50 rounded-lg p-4">
                 <h3 className="font-semibold text-gray-900 mb-2 flex items-center">
-                  <svg className="w-5 h-5 mr-2 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
-                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+                  <svg
+                    className="w-5 h-5 mr-2 text-gray-600"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                    />
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                    />
                   </svg>
                   Estadio
                 </h3>
                 <p className="text-gray-700">
-                  {betisHome ? 'Estadio Benito Villamarín' : `Estadio del ${opponent.name}`}
+                  {betisHome
+                    ? "Estadio Benito Villamarín"
+                    : `Estadio del ${opponent.name}`}
                 </p>
                 <p className="text-sm text-gray-600">
-                  {betisHome ? 'Sevilla, España' : 'Estadio visitante'}
+                  {betisHome ? "Sevilla, España" : "Estadio visitante"}
                 </p>
               </div>
 
@@ -296,8 +332,18 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
               {match.stage && (
                 <div className="bg-gray-50 rounded-lg p-4 sm:col-span-2 lg:col-span-1">
                   <h3 className="font-semibold text-gray-900 mb-2 flex items-center">
-                    <svg className="w-5 h-5 mr-2 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z" />
+                    <svg
+                      className="w-5 h-5 mr-2 text-gray-600"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M9 12l2 2 4-4M7.835 4.697a3.42 3.42 0 001.946-.806 3.42 3.42 0 014.438 0 3.42 3.42 0 001.946.806 3.42 3.42 0 013.138 3.138 3.42 3.42 0 00.806 1.946 3.42 3.42 0 010 4.438 3.42 3.42 0 00-.806 1.946 3.42 3.42 0 01-3.138 3.138 3.42 3.42 0 00-1.946.806 3.42 3.42 0 01-4.438 0 3.42 3.42 0 00-1.946-.806 3.42 3.42 0 01-3.138-3.138 3.42 3.42 0 00-.806-1.946 3.42 3.42 0 010-4.438 3.42 3.42 0 00.806-1.946 3.42 3.42 0 013.138-3.138z"
+                      />
                     </svg>
                     Fase
                   </h3>
@@ -311,21 +357,38 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
           </div>
 
           {/* Additional Match Information */}
-          {(match.referees && match.referees.length > 0) && (
+          {match.referees && match.referees.length > 0 && (
             <div className="border-t pt-6 mt-6">
               <h3 className="font-semibold text-gray-900 mb-4 flex items-center">
-                <svg className="w-5 h-5 mr-2 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                <svg
+                  className="w-5 h-5 mr-2 text-gray-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
                 </svg>
                 Árbitros
               </h3>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                 {match.referees.map((referee) => (
-                  <div key={`${referee.id}-${referee.name}`} className="bg-gray-50 rounded-lg p-4">
+                  <div
+                    key={`${referee.id}-${referee.name}`}
+                    className="bg-gray-50 rounded-lg p-4"
+                  >
                     <p className="font-medium text-gray-900">{referee.name}</p>
-                    <p className="text-sm text-gray-600 capitalize">{referee.type?.toLowerCase().replace('_', ' ')}</p>
+                    <p className="text-sm text-gray-600 capitalize">
+                      {referee.type?.toLowerCase().replace("_", " ")}
+                    </p>
                     {referee.nationality && (
-                      <p className="text-sm text-gray-600">{referee.nationality}</p>
+                      <p className="text-sm text-gray-600">
+                        {referee.nationality}
+                      </p>
                     )}
                   </div>
                 ))}
@@ -334,18 +397,30 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
           )}
 
           {/* Score Details for Finished Matches */}
-          {match.status === 'FINISHED' && match.score && (
+          {match.status === "FINISHED" && match.score && (
             <div className="border-t pt-6 mt-6">
               <h3 className="font-semibold text-gray-900 mb-4 flex items-center">
-                <svg className="w-5 h-5 mr-2 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+                <svg
+                  className="w-5 h-5 mr-2 text-gray-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+                  />
                 </svg>
                 Detalles del Resultado
               </h3>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
                 {/* Full Time */}
                 <div className="bg-gray-50 rounded-lg p-4 text-center">
-                  <p className="text-sm text-gray-600 mb-1">Tiempo Reglamentario</p>
+                  <p className="text-sm text-gray-600 mb-1">
+                    Tiempo Reglamentario
+                  </p>
                   <p className="text-2xl font-bold text-gray-900">
                     {match.score.fullTime.home} - {match.score.fullTime.away}
                   </p>
@@ -362,24 +437,28 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
                 )}
 
                 {/* Extra Time */}
-                {match.score.extraTime && match.score.extraTime.home !== null && (
-                  <div className="bg-gray-50 rounded-lg p-4 text-center">
-                    <p className="text-sm text-gray-600 mb-1">Prórroga</p>
-                    <p className="text-xl font-semibold text-gray-900">
-                      {match.score.extraTime.home} - {match.score.extraTime.away}
-                    </p>
-                  </div>
-                )}
+                {match.score.extraTime &&
+                  match.score.extraTime.home !== null && (
+                    <div className="bg-gray-50 rounded-lg p-4 text-center">
+                      <p className="text-sm text-gray-600 mb-1">Prórroga</p>
+                      <p className="text-xl font-semibold text-gray-900">
+                        {match.score.extraTime.home} -{" "}
+                        {match.score.extraTime.away}
+                      </p>
+                    </div>
+                  )}
 
                 {/* Penalties */}
-                {match.score.penalties && match.score.penalties.home !== null && (
-                  <div className="bg-gray-50 rounded-lg p-4 text-center">
-                    <p className="text-sm text-gray-600 mb-1">Penaltis</p>
-                    <p className="text-xl font-semibold text-gray-900">
-                      {match.score.penalties.home} - {match.score.penalties.away}
-                    </p>
-                  </div>
-                )}
+                {match.score.penalties &&
+                  match.score.penalties.home !== null && (
+                    <div className="bg-gray-50 rounded-lg p-4 text-center">
+                      <p className="text-sm text-gray-600 mb-1">Penaltis</p>
+                      <p className="text-xl font-semibold text-gray-900">
+                        {match.score.penalties.home} -{" "}
+                        {match.score.penalties.away}
+                      </p>
+                    </div>
+                  )}
               </div>
             </div>
           )}
@@ -392,12 +471,22 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
             href="/partidos"
             className="inline-flex items-center justify-center px-6 py-3 border border-betis-verde text-betis-verde font-medium rounded-lg hover:bg-betis-verde-pale transition-colors shadow-md"
           >
-            <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M10 19l-7-7m0 0l7-7m-7 7h18"
+              />
             </svg>
             Volver a Partidos
           </Link>
-          
+
           {/* Share Component */}
           <ShareMatch match={match} opponent={opponent} />
         </div>
@@ -407,7 +496,9 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
 }
 
 // Main page component with error boundary and loading
-export default async function MatchDetailPage({ params }: MatchDetailPageProps) {
+export default async function MatchDetailPage({
+  params,
+}: MatchDetailPageProps) {
   const { matchId: matchIdString } = await params;
   const matchId = parseInt(matchIdString);
 
@@ -417,11 +508,13 @@ export default async function MatchDetailPage({ params }: MatchDetailPageProps) 
 
   return (
     <ErrorBoundary>
-      <Suspense fallback={
-        <div className="min-h-screen bg-gradient-to-b from-green-50 to-white flex items-center justify-center">
-          <LoadingSpinner />
-        </div>
-      }>
+      <Suspense
+        fallback={
+          <div className="min-h-screen bg-gradient-to-b from-green-50 to-white flex items-center justify-center">
+            <LoadingSpinner />
+          </div>
+        }
+      >
         <MatchDetailContent matchId={matchId} />
       </Suspense>
     </ErrorBoundary>

--- a/src/app/partidos/[matchId]/page.tsx
+++ b/src/app/partidos/[matchId]/page.tsx
@@ -140,13 +140,13 @@ async function MatchDetailContent({ matchId }: { matchId: number }) {
         <nav className="mb-8" aria-label="Navegación de migas de pan">
           <ol className="flex items-center space-x-2 text-sm text-gray-600">
             <li>
-              <Link href="/" className="hover:text-betis-verde transition-colors">
+              <Link href="/" className="hover:text-betis-verde-dark transition-colors">
                 Inicio
               </Link>
             </li>
             <li className="text-gray-400">/</li>
             <li>
-              <Link href="/partidos" className="hover:text-betis-verde transition-colors">
+              <Link href="/partidos" className="hover:text-betis-verde-dark transition-colors">
                 Partidos
               </Link>
             </li>


### PR DESCRIPTION
## Summary

This PR resolves a visual inconsistency introduced in #443 where hover states for `betis-verde` text unexpectedly lightened on white backgrounds. The static `.text-betis-verde` class uses the accessible dark green (`#036B38`), while the Tailwind-generated hover variant used the brighter brand green (`#048D47`). This PR migrates five call sites across the homepage, match pages, and historical players page to use `hover:text-betis-verde-dark`, ensuring that hover states consistently darken the text for predictable visual feedback.

Two instances in `src/components/layout/Footer.tsx` are intentionally excluded from this migration. These elements appear on the dark `scotland-navy` background, where the brighter green variant provides superior contrast compared to the darker accessible variant. Migrating these specific cases would degrade readability and visual hierarchy within the footer component.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [x] `npm test` passes (no behavioural change)
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code) (description drafted via local Ollama)